### PR TITLE
Fix the validation order when performing a transfer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,6 @@ jobs:
         restore-keys: ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-dialyzer-
     - name: Create PLTs
       if: steps.dialyzer_plt_cache.outputs.cache-hit != 'true'
-      run: mkdir _build/dialyzer && mix dialyzer --plt
+      run: mkdir -p _build/dialyzer && mix dialyzer --plt
     - name: Run Dialyzer
       run: mix dialyzer

--- a/lib/ex_double_entry/services/transfer.ex
+++ b/lib/ex_double_entry/services/transfer.ex
@@ -52,8 +52,8 @@ defmodule ExDoubleEntry.Transfer do
   defp do_perform(transfer, accounts, ensure_accounts: ensure_accounts) when is_list(accounts) do
     transfer = ensure_accounts_if_needed!(ensure_accounts, transfer, accounts)
 
-    with {:ok, _} <- Guard.positive_balance_if_enforced?(transfer),
-         {:ok, _} <- Guard.idempotent_if_provided?(transfer) do
+    with {:ok, _} <- Guard.idempotent_if_provided?(transfer),
+         {:ok, _} <- Guard.positive_balance_if_enforced?(transfer) do
       line1 =
         Line.insert!(MoneyProxy.neg(transfer.money),
           account: transfer.from,

--- a/test/ex_double_entry/transfer_test.exs
+++ b/test/ex_double_entry/transfer_test.exs
@@ -59,24 +59,38 @@ defmodule ExDoubleEntry.TransferTest do
       assert Line |> ExDoubleEntry.repo().all() |> Enum.count() == 0
     end
 
+    test "handles positive only account flag", %{acc_a: acc_a, acc_b: acc_b} do
+      uuid = Ecto.UUID.generate()
+
+      assert {:error, :insufficient_balance,
+              "Transfer: USD 30000, from :savings (balance amount: 20000) to :checking"} =
+               Transfer.perform!(%Transfer{
+                 money: MoneyProxy.new(30000, :USD),
+                 from: acc_b,
+                 to: acc_a,
+                 code: :withdraw,
+                 idempotence: uuid
+               })
+    end
+
     test "idempotence", %{acc_a: acc_a, acc_b: acc_b} do
       uuid = Ecto.UUID.generate()
 
       assert {:ok, _transfer} =
                Transfer.perform!(%Transfer{
                  money: MoneyProxy.new(123_45, :USD),
-                 from: acc_a,
-                 to: acc_b,
-                 code: :deposit,
+                 from: acc_b,
+                 to: acc_a,
+                 code: :withdraw,
                  idempotence: uuid
                })
 
       assert {:error, :non_idempotent_transfer, _} =
                Transfer.perform!(%Transfer{
                  money: MoneyProxy.new(123_45, :USD),
-                 from: acc_a,
-                 to: acc_b,
-                 code: :deposit,
+                 from: acc_b,
+                 to: acc_a,
+                 code: :withdraw,
                  idempotence: uuid
                })
     end


### PR DESCRIPTION
The "positive only?" check has to be done after idempotency check. Otherwise, it may report "insufficient balance" error.