### PR TITLE
cldr: only compile code when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         elixir-version: ${{ matrix.elixir }}
         otp-version: ${{ matrix.otp }}
     - name: Restore dependencies cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: deps
         key: ${{ runner.os }}-${{ steps.beam.outputs.otp-version }}-${{ steps.beam.outputs.elixir-version }}-mix-${{ hashFiles('**/mix.lock') }}
@@ -57,7 +57,7 @@ jobs:
     - name: Run formatting check
       run: mix format --check-formatted
     - name: Restore Dialyzer PLT cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: dialyzer_plt_cache
       with:
         path: _build/dialyzer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           - 3306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Set up Elixir
       id: beam
       uses: erlef/setup-beam@v1

--- a/lib/ex_double_entry/cldr.ex
+++ b/lib/ex_double_entry/cldr.ex
@@ -1,4 +1,4 @@
-if Code.ensure_loaded?(Cldr) do
+if "#{Mix.env()}" =~ "test" and Code.ensure_loaded?(Cldr) do
   defmodule ExDoubleEntry.Cldr do
     use Cldr,
       locales: ["en"],


### PR DESCRIPTION
This code causes an error when compiling Coinbits with elixir-1.19.2-otp-28. Looks like we only use this cldr code in tests so looked to me like the easiest fix was to add an extra guard.